### PR TITLE
bug fix: redirect not working with logged in users

### DIFF
--- a/SessionTimeout/widget/SessionTimeout.js
+++ b/SessionTimeout/widget/SessionTimeout.js
@@ -110,9 +110,11 @@ define([
                                     window.location.href = redirect;
                                 }
                             } else {
-                                mx.session.logout();
-                                if (redirect) {
+                                if (redirect){
+                                    mx.session.logout();
                                     window.location.href = redirect;
+                                } else {
+                                    mx.logout();
                                 }
                             }
                         }

--- a/SessionTimeout/widget/SessionTimeout.js
+++ b/SessionTimeout/widget/SessionTimeout.js
@@ -110,7 +110,7 @@ define([
                                     window.location.href = redirect;
                                 }
                             } else {
-                                mx.logout();
+                                mx.session.logout();
                                 if (redirect) {
                                     window.location.href = redirect;
                                 }

--- a/package.xml
+++ b/package.xml
@@ -1,6 +1,7 @@
-<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="SessionTimeout" version="2.1.2" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="SessionTimeout" version="2.1.3"
+        xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="SessionTimeout/SessionTimeout.xml" />
         </widgetFiles>


### PR DESCRIPTION
The redirect was not working in 9.18+ if the user was already logged into a session. Changed to mx.session.logout() so the session logout runs async to the redirect.